### PR TITLE
Fix PPFX and Depth3D using the same texture name for different purposes

### DIFF
--- a/Shaders/PPFX_SSDO.fx
+++ b/Shaders/PPFX_SSDO.fx
@@ -150,7 +150,7 @@ uniform int pSSDODebugMode <
 
 // *** ESSENTIALS ***
 texture texColorLOD { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; Format = RGBA8; MipLevels = 4; };
-texture texDepth : DEPTH;
+texture texGameDepth : DEPTH;
 
 // *** FX RTs ***
 texture texViewSpace
@@ -201,7 +201,7 @@ sampler SamplerColorLOD
 
 sampler2D SamplerDepth
 {
-	Texture = texDepth;
+	Texture = texGameDepth;
 };
 
 // *** FX RTs ***


### PR DESCRIPTION
Please see: https://github.com/crosire/reshade-shaders/commit/3b54990a4aeaebcb53cb266e5221a1acdd3574b8